### PR TITLE
Update publications (end of October 2022)

### DIFF
--- a/docs/dissemination/publications.md
+++ b/docs/dissemination/publications.md
@@ -4,31 +4,52 @@
 
 ### 2022
 
-1. Pascal Reisert, Marc Rivinius, Toomas Krips and Ralf Kuesters: _Arithmetic
+1. Marc Rivinius, Pascal Reisert, Daniel Rausch, and Ralf Küsters: _Publicly
+Accountable Robust Multi-Party Computation_. In 2022 IEEE Symposium on Security
+and Privacy, SP 2022, San Francisco, CA, US, May 22-26, pp. 2430-2449. <br>
+:material-file-document-outline: [Conference Version](https://doi.org/10.1109/SP46214.2022.9833608) &emsp;
+:material-file-document-multiple-outline: [Technical Report](https://eprint.iacr.org/2022/436) &emsp;
+:material-presentation: [Slides](https://drive.google.com/file/d/18meTQbIoPo8oqBo465Wv-vmLTaMCVqqX/view?usp=sharing) &emsp;
+:material-video: [Recording](https://www.youtube.com/watch?v=WycM5GDkRr0)
+
+1. Pascal Reisert, Marc Rivinius, Toomas Krips, and Ralf Kuesters: _Arithmetic
 Tuples for MPC_. In Cryptology ePrint Archive, Paper 2022/667. <br>
 :material-file-document-multiple-outline: [Technical Report](https://eprint.iacr.org/2022/667)
 
-2. Marc Rivinius, Pascal Reisert, Daniel Rausch and Ralf Küsters: _Publicly
-Accountable Robust Multi-Party Computation_. In 2022 IEEE Symposium on Security
-and Privacy (SP), San Francisco, CA, US, 2022, pp. 1520-1520. <br>
-:material-file-document-outline: [Conference Version](https://doi.ieeecomputersociety.org/10.1109/SP46214.2022.00091)
-&emsp; :material-file-document-multiple-outline: [Technical Report](https://eprint.iacr.org/2022/436)
-
-3. David Mestel, Johannes Müller, and Pascal Reisert: _How Efficient are Replay
+1. David Mestel, Johannes Müller, and Pascal Reisert: _How Efficient are Replay
 Attacks against Vote Privacy? A Formal Quantitative Analysis_. In 35th IEEE
 Computer Security Foundations Symposium, CSF 2022, Haifa, Israel, August 7-10,
 to appear. <br>
 :material-file-document-multiple-outline: [Technical Report](https://eprint.iacr.org/2022/743)
 
-4. Natasha Fernandes, Annabelle McIver, Catuscia Palamidessi, and Ming Ding.
-_Universal Optimality and Robust Utility Bounds for Metric Differential Privacy_
-. In 35th IEEE Computer Security Foundations Symposium, CSF 2022, Haifa, Israel,
+1. Natasha Fernandes, Annabelle McIver, Catuscia Palamidessi, and Ming Ding:
+_Universal Optimality and Robust Utility Bounds for Metric Differential Privacy_.
+In 35th IEEE Computer Security Foundations Symposium, CSF 2022, Haifa, Israel,
 August 7-10, to appear. <br>
 :material-file-document-multiple-outline: [Technical Report](https://doi.org/10.48550/arXiv.2205.01258)
+
+1. Nicolas Huber, Ralf Küsters, Toomas Krips, Julian Liedtke, Johannes Müller,
+Daniel Rausch, Pascal Reisert, and Andreas Vogt: _Kryvos: Publicly
+Tally-Hiding Verifiable E-Voting_. In Proceedings of the 2022 ACM SIGSAC
+Conference on Computer and Communications Security, CCS 2022, Los Angeles, CA,
+USA, November 7-11, to appear. <br>
+:material-file-document-multiple-outline: [Technical Report](https://eprint.iacr.org/2022/1132)
+
+1. Mayar Elfares, Zhiming Hu, Pascal Reisert, Andreas Bulling, and Ralf Küsters:
+_Federated Learning for Appearance-based Gaze Estimation in the Wild_.
+NeurIPS 2022 Gaze Meets ML Workshop, GMML 2022, New Orleans, LA, USA, December
+3, to appear in the Proceedings for Machine Learning Research (PMLR).
 
 ## Talks
 
 ### 2022
+
+1. Catuscia Palamidessi: _Differential Privacy: From the Central Model to the
+Local Model and their Generalization_. Invited talk at the Collège de France,
+Sécurité du logiciel: quel rôle pour les langages de programmation? 2022, Paris,
+France, March 24. <br>
+:material-presentation: [Slides](https://www.college-de-france.fr/sites/default/files/documents/xavier-leroy/UPL2506661257705268028_Palamidessi.pdf) &emsp;
+:material-video: [Recording](https://www.college-de-france.fr/agenda/seminaire/securite-du-logiciel-quel-role-pour-les-langages-de-programmation/differential-privacy-from-the-central-model-to-the-local-model-and-their-generalization)
 
 1. Sven Trieflinger: _Carbyne Stack – Open-source cloud-native Secure Multiparty
 Computation_. Invited talk at Workshop on Theory and Practice of Multi-Party
@@ -38,17 +59,30 @@ Computation, TPMPC 2022, Aarhus, Denmark, June 7-10. <br>
 (access restricted) &emsp;
 :material-video: [Recording](https://www.youtube.com/watch?v=IeI3Lb0xVgg)
 
-2. Sven Trieflinger: _Carbyne Stack - Cloud Native Computing on Encrypted Data_.
+1. Sven Trieflinger: _Carbyne Stack - Cloud Native Computing on Encrypted Data_.
 Contributed talk at Emerging OS Forum, Open Source Summit North America 2022,
 OSS-NA 2022, Austin, Texas, USA, June 21-24. <br>
 :material-text-short: [Abstract](https://ossna2022.sched.com/event/11NhT) &emsp;
 :material-presentation: [Slides](https://static.sched.com/hosted_files/ossna2022/6b/20220623%20Carbyne%20Stack%20-%20Cloud%20Native%20Computing%20on%20Encrypted%20Data.pdf)
 
-3. Sven Trieflinger: _Scaling the Grail - Cloud-Native Computing on Encrypted
+1. Sven Trieflinger: _Scaling the Grail - Cloud-Native Computing on Encrypted
 Data using Carbyne Stack_. Invited talk at StackConf '22, Berlin, Germany,
 July 19-22. <br>
 :material-text-short: [Abstract](https://stackconf.eu/talks/scaling-the-grail-cloud-native-computing-on-encrypted-data-using-carbyne-stack/) &emsp;
 :material-video: [Recording](https://www.youtube.com/watch?v=0ELrWOaDZq8)
+
+1. Catuscia Palamidessi: _Information Structures for Privacy and Fairness_.
+Keynote at the Federated Logic Conference, FLoC 2022, Haifa, Israel, July
+31-August 12. <br>
+:material-video: [Recording](https://www.youtube.com/watch?v=FnwEkypluT0)
+
+1. Sven Trieflinger: _One year of Carbyne Stack - Retrospective and Outlook_.
+Contributed talk at CarbyneStackCon 2022, Stuttgart, Germany, October 27. <br>
+:material-text-short: [Abstract](https://carbynestack.io/community/csc/overview/#program)
+
+1. Pascal Reisert: _Generalized Tuples for MP-SPDZ_. Contributed talk at
+CarbyneStackCon 2022, Stuttgart, Germany, October 27. <br>
+:material-text-short: [Abstract](https://carbynestack.io/community/csc/overview/#program)
 
 ## Software
 


### PR DESCRIPTION
This updates some items of the publication list and adds new ones.
Some details (links to conference versions of paper, DOIs, etc.) are still missing at the moment and will be added at a later date.

I ordered the papers by conference date (or upload date for technical reports if there is not conference submission at the moment) and talks by the date of the talk (or conference).
The numbering for entries is changed to `1.` for all entries so inserting new elements anywhere but at the end does not require updating all later entries. (Markdown viewers and the website sill show incremental numbering 1., 2., ...)